### PR TITLE
build(plugin): remove commitizen dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 node_js:
   - node
   - "10"
+  - "8"
 script: yarn test:ci

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     "@types/jsonwebtoken": "^8.3.2",
     "@types/node": "^12.6.8",
     "@types/node-jose": "^1.1.0",
-    "commitizen": "^4.0.3",
     "coveralls": "^3.0.5",
-    "cz-conventional-changelog": "3.0.2",
     "husky": "^3.0.1",
     "jest": "^24.8.0",
     "jest-axios-mock": "^1.0.0",
@@ -43,16 +41,10 @@
     "prebuild": "rimraf dist/",
     "prepublishOnly": "yarn build"
   },
-  "config": {
-    "commitizen": {
-      "path": "./node_modules/cz-conventional-changelog"
-    }
-  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
-      "pre-push": "yarn test",
-      "prepare-commit-msg": "exec < /dev/tty && git cz --hook"
+      "pre-push": "yarn test"
     }
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "scripts": {
     "test": "jest",
-    "test:ci": "jest --coverage --coverageReporters=text-lcov | coveralls",
+    "test:ci": "jest --coverage",
+    "posttest:ci": "cat coverage/lcov.info | coveralls",
     "build": "tsc",
     "prebuild": "rimraf dist/",
     "prepublishOnly": "yarn build"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5,6 +5,8 @@ import jose from "node-jose";
 
 import fastifyAwsCognitoPlugin, { FastifyAwsCognitoPluginOptions } from ".";
 
+jest.setTimeout(10 * 1000);
+
 describe("FastifyAwsCognitoPlugin", () => {
   let instance: FastifyInstance;
 


### PR DESCRIPTION
This dependency required Node.js 10, be dropping it, we now should support Node.js 8

fix #4